### PR TITLE
Add google analytics tags with lib and type directory

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { PrismicPreview } from "@prismicio/next";
 import { repositoryName } from "@/prismicio";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import GoogleAnalytics from "@/components/GoogleAnalytics";
 
 
 const dmSans = DM_Sans({
@@ -25,12 +26,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${dmSans.variable} ${roboto_mono.variable}`}>
+      <head>
+        <GoogleAnalytics />
+      </head>
       <body className="bg-[#070815] text-white">
         <Header />
         <main>{children}</main>
-        
         <Footer/>
-        </body>
+      </body>
       <PrismicPreview repositoryName={repositoryName} />
     </html>
   );

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,26 @@
+
+import Script from 'next/script'
+import { GA_TRACKING_ID } from '../lib/gtag'
+
+export default function GoogleAnalytics() {
+  return (
+    <>
+      <Script
+        strategy="afterInteractive"
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+      />
+      <Script
+        id="gtag-init"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_TRACKING_ID}');
+          `,
+        }}
+      />
+    </>
+  )
+}

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -1,0 +1,26 @@
+export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID || ''
+
+if (!GA_TRACKING_ID) {
+  console.warn('Google Analytics ID is not defined in environment variables')
+}
+
+type GTagEvent = {
+  action: string;
+  category: string;
+  label: string;
+  value: number;
+}
+
+export const pageview = (url: string) => {
+  window.gtag('config', GA_TRACKING_ID, {
+    page_path: url,
+  })
+}
+
+export const event = ({ action, category, label, value }: GTagEvent) => {
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  })
+}

--- a/src/types/gtag.d.ts
+++ b/src/types/gtag.d.ts
@@ -1,0 +1,11 @@
+declare global {
+    interface Window {
+      gtag: (
+        command: string,
+        target: string | object,
+        config?: object | undefined
+      ) => void;
+    }
+  }
+  
+  export {};


### PR DESCRIPTION
First, create src/types/gtag.d.ts:

Create src/lib/gtag.ts:

Create src/components/GoogleAnalytics.tsx:

Update src/app/layout.tsx:

These are utility functions for tracking specific events and page views, and they should actually be in your src/lib/gtag.ts file, not in GoogleAnalytics.tsx. 


This implementation:

Provides TypeScript types for better type safety
Uses Next.js's Script component for optimal loading
Maintains your existing layout structure and styling
Works alongside your Prismic preview functionality
This implementation:

Provides TypeScript types for better type safety
Uses Next.js's Script component for optimal loading
Maintains your existing layout structure and styling
Works alongside your Prismic preview functionality